### PR TITLE
Allow installation of arm releases

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -38,11 +38,6 @@ install() {
   local platform
   [ "Linux" = "$(uname)" ] && platform="linux" || platform="darwin"
 
-  if [ "$(uname -m)" != "x86_64" ]; then
-    echo "ERROR: only 64-bit platforms have releases"
-    exit 1
-  fi
-
   local download_package="pulumi-v${version}-${platform}-x64.tar.gz"
   local download_url="${repo_url}/${download_package}"
 


### PR DESCRIPTION
Hi! First of all thanks for making this plugin, have been using it for a while :).

This PR allows the installation of `arm64` packages for Linux and Darwin.

I just got an M1 Mac and noticed the  plugin does not allow installing `arm64` releases at the moment, even though these are supported for newer Pulumi versions. Older releases (e.g [this one](https://github.com/pulumi/pulumi/releases/tag/v2.11.0) do not seem to have been updated with an arm release, so I'm not sure if we want to check for that or not, currently that fails with:

```
Downloading pulumi from https://get.pulumi.com/releases/sdk/pulumi-v2.11.0-darwin-x64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 60.1M  100 60.1M    0     0  14.4M      0  0:00:04  0:00:04 --:--:-- 14.4M
chmod: /Users/jim/.asdf/installs/pulumi/2.11.0/bin/pulumi: No such file or directory
```

I'd be happy to contribute a check for that too.