### PR TITLE
Fix installation for different architectures

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -25,8 +25,19 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 # shellcheck source=../lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
-[ -z "${ASDF_INSTALL_TYPE+x}" ] && echo "ASDF_INSTALL_TYPE is required" && exit 1
-[ -z "${ASDF_INSTALL_VERSION+x}" ] && echo "ASDF_INSTALL_VERSION is required" && exit 1
-[ -z "${ASDF_INSTALL_PATH+x}" ] && echo "ASDF_INSTALL_PATH is required" && exit 1
+mkdir -p "$ASDF_DOWNLOAD_PATH"
 
-install_version "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"
+platform=$(get_platform)
+arch=$(get_architecture)
+
+release_basename="${TOOL_NAME}-v${ASDF_INSTALL_VERSION}-${platform}-${arch}.tar.gz"
+release_file="${ASDF_DOWNLOAD_PATH}/${release_basename}"
+
+# Download tar.gz file to the download directory
+download_release "${ASDF_INSTALL_VERSION}" "${release_basename}" "${release_file}"
+
+#  Extract contents of tar.gz file into the download directory
+tar -xzf "$release_file" -C "${ASDF_DOWNLOAD_PATH}" --strip-components=1 || fail "Could not extract $release_file"
+
+# Remove the tar.gz file since we don't need to keep it
+rm "$release_file"

--- a/bin/list-all
+++ b/bin/list-all
@@ -17,41 +17,12 @@
 # You should have received a copy of the GNU General Public License
 # along with asdf-pulumi.  If not, see <http://www.gnu.org/licenses/>.
 
-versions_path=https://www.pulumi.com/docs/get-started/install/versions/
-versions_list="$(curl -s $versions_path)"
+set -euo pipefail
 
-ensure_compatible_version() {
-  semver=( ${1//./ } )
-  major="${semver[0]}"
-  minor="${semver[1]}"
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-  if [ $major -eq 0 ]; then
-    if [ $minor -lt 16 ]; then
-      return
-    fi
-  fi
-  echo "${1}"
-}
+# shellcheck source=../lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
 
-get_version() {
-  awk '{gsub("http", "\nhttp", $0); print}' \
-  | grep -oE "/releases/sdk/pulumi-v(.+)-linux-x64.tar.gz" \
-  | sed 's|/releases/sdk/pulumi-v||;s|-linux-x64.tar.gz||;' \
-  | sed -e '/^0.12/d ; /^0.13/d ; /^0.14/d ; /^0.15/d'
-  # This line above is a small hack to delete older releases
-  # with a different archive structure, most people shouldn't
-  # need using an old legacy Pulumi versions.
-  # TLDR: supporting only v0.16+ upwards
-}
-
-# stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
-sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$//; G; s/\n/ /' | \
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
-}
-
-list_all() {
-  echo "${versions_list}" | get_version | sort_versions | tr '\n' ' '
-}
-
-list_all
+list_all_versions | sort_versions | xargs echo

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -51,7 +51,7 @@ get_architecture() {
     ;;
 
   "x86_64")
-    echo "x86"
+    echo "x64"
     ;;
 
   *)

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2019-2020 Jorge Canha
+#
+# This file is part of asdf-pulumi.
+#
+# asdf-pulumi is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# asdf-pulumi is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with asdf-pulumi.  If not, see <http://www.gnu.org/licenses/>.
+
+set -euo pipefail
+
+GH_REPO="https://github.com/pulumi/pulumi"
+TOOL_NAME="pulumi"
+TOOL_TEST="pulumi version"
+
+get_platform() {
+  local uname_platform="$(uname)"
+
+  case "${uname_platform}" in
+  "Darwin")
+    echo "darwin"
+    ;;
+
+  "Linux")
+    echo "linux"
+    ;;
+
+  *)
+    echo "Platform ${uname_platform} is not supported."
+    exit 1
+    ;;
+  esac
+}
+
+get_architecture() {
+  local uname_arch="$(uname -m)"
+
+  case "${uname_arch}" in
+  "arm64" | "aarch64")  # Mac M1 and Linux ARM
+    echo "arm64"
+    ;;
+
+  "x86_64")
+    echo "x86"
+    ;;
+
+  *)
+    echo "Architecture ${uname_arch} is not supported."
+    exit 1
+    ;;
+  esac
+}
+
+
+fail() {
+  echo -e "asdf-$TOOL_NAME: $*"
+  exit 1
+}
+
+curl_opts=(-fsSL)
+
+# NOTE: You might want to remove this if pulumi is not hosted on GitHub releases.
+if [ -n "${GITHUB_API_TOKEN:-}" ]; then
+  curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
+fi
+
+sort_versions() {
+  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
+    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+}
+
+# NOTE: You might want to adapt this sed to remove non-version strings from tags
+list_github_tags() {
+  git ls-remote --tags --refs "$GH_REPO" |
+    grep -o 'refs/tags/v.*' | cut -d/ -f3- |
+    sed 's/^v//'
+}
+
+list_all_versions() {
+  list_github_tags
+}
+
+download_release() {
+  local version filename url
+  version="$1"
+  file_basename="$2"
+  filename="$3"
+
+  url="$GH_REPO/releases/download/v${version}/${file_basename}"
+
+  echo "* Downloading $TOOL_NAME release $version..."
+  curl "${curl_opts[@]}" -o "${filename}" -C - "$url" || fail "Could not download $url"
+}
+
+install_version() {
+
+
+
+  local install_type="$1"
+  local version="$2"
+  local install_path="$3"
+  local bin_install_path="${install_path}/bin"
+  echo "$1" ... "$2" ... "$3"
+
+  if [ "$install_type" != "version" ]; then
+    fail "asdf-$TOOL_NAME supports release installs only"
+  fi
+
+  (
+    mkdir -p "${bin_install_path}"
+    cp -r "${ASDF_DOWNLOAD_PATH}"/* "${bin_install_path}"
+
+    # Asert pulumi executable exists.
+    local tool_cmd
+    tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
+    test -x "${bin_install_path}/${tool_cmd}" || fail "Expected ${bin_install_path}/${tool_cmd} to be executable."
+    echo "$TOOL_NAME $version installation was successful!"
+  ) || (
+    rm -rf "$install_path"
+    fail "An error occurred while installing $TOOL_NAME $version."
+  )
+}


### PR DESCRIPTION
Hi, I noticed that the [previous commit](https://github.com/canha/asdf-pulumi/commit/3e56e8e541a525e6e6ae186a348866544b3cfc93) lies in the commit message and x64 pulumi binaries are still being installed instead of receiving proper arm binaries. 

In the scope of this PR I also:

* Partially adopted new plugin template https://github.com/asdf-vm/asdf-plugin-template
* Used GitHub releases instead of the pulumi website